### PR TITLE
Test that mimics the sinus function

### DIFF
--- a/Examples/OS X/SimpleTest/SimpleTest.swift
+++ b/Examples/OS X/SimpleTest/SimpleTest.swift
@@ -98,6 +98,17 @@ extension Builder {
 		append([1, 1, 0], [0])
 		append([1, 1, 1], [1])
 	}
+	
+	func sinus() {
+		name = "Mimic the Sinus function"
+		let n = 19
+		for i in 0...n {
+			let input: Float = Float(i) / Float(n)
+			let rad: Float = Float(M_PI * 2) * input
+			let output: Float = (sin(rad) + 1) / 2
+			append([input], [output])
+		}
+	}
 }
 
 class SimpleTest: XCTestCase {
@@ -136,6 +147,24 @@ class SimpleTest: XCTestCase {
 		b.prettyPrint()
 		
 		XCTAssertLessThan(b.absoluteError, 0.1)
+	}
+	
+	func testSinus() {
+		let network = FFNN(inputs: 1, hidden: 10, outputs: 1, learningRate: 0.2, momentum: 0.1, weights: nil)
+		
+		let b = Builder()
+		b.sinus()
+		
+		try! network.train(inputs: b.inputs, answers: b.answers,
+			testInputs: b.inputs, testAnswers: b.answers,
+			errorThreshold: 0.1)
+		
+		for row in b.rows {
+			row.actualAnswer = try! network.update(inputs: row.input)
+		}
+		b.prettyPrint()
+		
+		XCTAssertLessThan(b.absoluteError, 0.9)
 	}
 	
 }


### PR DESCRIPTION
On [stack overflow](http://stackoverflow.com/questions/963041/data-sets-for-neural-network-training) people suggest to mimic the sinus function.

So here is a test that does this. The accumulated error is higher than for the other tests. I have tried tweaking the FFNN parameters, but can't find a really good optimum.

	=========== Mimic the Sinus function ===========
	[0.0] -> [0.5] vs. [0.511029]
	[0.0526316] -> [0.66235] vs. [0.684057]
	[0.105263] -> [0.807106] vs. [0.806131]
	[0.157895] -> [0.918583] vs. [0.877269]
	[0.210526] -> [0.9847] vs. [0.913682]
	[0.263158] -> [0.998292] vs. [0.928051]
	[0.315789] -> [0.957887] vs. [0.924549]
	[0.368421] -> [0.867862] vs. [0.896043]
	[0.421053] -> [0.737974] vs. [0.815031]
	[0.473684] -> [0.582297] vs. [0.634151]
	[0.526316] -> [0.417703] vs. [0.379301]
	[0.578947] -> [0.262026] vs. [0.191267]
	[0.631579] -> [0.132138] vs. [0.105954]
	[0.684211] -> [0.0421133] vs. [0.0762194]
	[0.736842] -> [0.00170776] vs. [0.072949]
	[0.789474] -> [0.0152999] vs. [0.0885684]
	[0.842105] -> [0.0814169] vs. [0.12721]
	[0.894737] -> [0.192894] vs. [0.200611]
	[0.947368] -> [0.33765] vs. [0.321438]
	[1.0] -> [0.5] vs. [0.48558]
	absolute error: 0.804818