### PR TITLE
.DS_Store Banished

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store 
+
+
 Examples/OS X/Swift-AI-OSX.xcodeproj/project.xcworkspace/xcuserdata/*
 Examples/OS X/Swift-AI-OSX.xcodeproj/xcuserdata/*
 Examples/iOS/Swift-AI-iOS.xcodeproj/project.xcworkspace/xcuserdata/*
@@ -7,3 +10,4 @@ Examples/iOS/Swift-AI-iOS.xcodeproj/xcuserdata/*
 # Examples/OS X/Swift-AI-OSX.xcodeproj/xcuserdata/andrea.xcuserdatad/xcschemes/Swift-AI-OSX.xcscheme
 # Examples/OS X/Swift-AI-OSX.xcodeproj/xcuserdata/andrea.xcuserdatad/xcschemes/Tests.xcscheme
 # Examples/OS X/Swift-AI-OSX.xcodeproj/xcuserdata/andrea.xcuserdatad/xcschemes/xcschememanagement.plist
+


### PR DESCRIPTION
First removed .DS_Store from Git tracking. Then added .DS_Store to .gitignore. 

The file has nothing to do with the code that is being tracked in git. It contains custom attributes set on the containing folder in the Finder. Unless those custom attributes are relevant to the code, that file is just noise. Additionally, if the file is not ignored and gets checked in unintentionally and later two devs each decide to put say, pretty custom icons on the folder (for whatever reason), then you could end up with a merge conflict on a binary file.