### PR TITLE
Fixes for Swift 2.2

### DIFF
--- a/Examples/OS X/Swift-AI-OSX/Handwriting.swift
+++ b/Examples/OS X/Swift-AI-OSX/Handwriting.swift
@@ -84,7 +84,7 @@ class HandwritingTrainer {
             }
             // Increment counters
             imagePosition += numPixels
-            labelPosition++
+            labelPosition += 1
         }
         self.trainImages = trainImages
         self.trainLabels = trainLabels
@@ -271,7 +271,7 @@ class HandwritingLearner {
             }
             // Increment counters
             imagePosition += numPixels
-            labelPosition++
+            labelPosition += 1
         }
         self.trainImages = trainImages
         self.trainLabels = trainLabels

--- a/Examples/Swift-AI-Playground.playground/Sources/FFNN.swift
+++ b/Examples/Swift-AI-Playground.playground/Sources/FFNN.swift
@@ -226,7 +226,7 @@ public final class FFNN: Storage {
         
         // Apply the activation function to the hidden layer nodes
         // Note: Array elements are shifted one index to the right, in order to efficiently insert the bias node at index 0
-        for (var i = self.numHidden; i > 0; --i) {
+        for i in (1...self.numHidden).reverse() {
             self.hiddenOutputCache[i] = self.activation(self.hiddenOutputCache[i - 1])
         }
         self.hiddenOutputCache[0] = 1.0

--- a/Examples/Swift-AI-Playground.playground/Sources/Storage.swift
+++ b/Examples/Swift-AI-Playground.playground/Sources/Storage.swift
@@ -9,7 +9,7 @@ import Foundation
 
 public protocol Storage {
     
-    typealias StorageType
+    associatedtype StorageType
     func writeToFile(filename: String)
     func writeToFile(url: NSURL)
     static func fromFile(filename: String) -> StorageType?

--- a/Source/FFNN.swift
+++ b/Source/FFNN.swift
@@ -446,33 +446,33 @@ public extension FFNN {
     private func activateHidden() {
         switch self.activationFunction {
         case .None:
-            for (var i = self.numHidden; i > 0; --i) {
+            for i in (1...self.numHidden).reverse() {
                 self.hiddenOutputCache[i] = 0.0
             }
             self.hiddenOutputCache[0] = 1.0
         case .Default:
-            for (var i = self.numHidden; i > 0; --i) {
+            for i in (1...self.numHidden).reverse() {
                 self.hiddenOutputCache[i] = sigmoid(self.hiddenOutputCache[i - 1])
             }
             self.hiddenOutputCache[0] = 1.0
         case .Linear:
-            for (var i = self.numHidden; i > 0; --i) {
+            for i in (1...self.numHidden).reverse() {
                 self.hiddenOutputCache[i] = linear(self.hiddenOutputCache[i - 1])
             }
             self.hiddenOutputCache[0] = 1.0
         case .Sigmoid, .Softmax:
             // For Softmax, apply Sigmoid activation for hidden layers
-            for (var i = self.numHidden; i > 0; --i) {
+            for i in (1...self.numHidden).reverse() {
                 self.hiddenOutputCache[i] = sigmoid(self.hiddenOutputCache[i - 1])
             }
             self.hiddenOutputCache[0] = 1.0
         case .RationalSigmoid:
-            for (var i = self.numHidden; i > 0; --i) {
+            for i in (1...self.numHidden).reverse() {
                 self.hiddenOutputCache[i] = rationalSigmoid(self.hiddenOutputCache[i - 1])
             }
             self.hiddenOutputCache[0] = 1.0
         case .HyperbolicTangent:
-            for (var i = self.numHidden; i > 0; --i) {
+            for i in (1...self.numHidden).reverse() {
                 self.hiddenOutputCache[i] = hyperbolicTangent(self.hiddenOutputCache[i - 1])
             }
             self.hiddenOutputCache[0] = 1.0

--- a/Source/Storage.swift
+++ b/Source/Storage.swift
@@ -14,7 +14,7 @@ import Foundation
 
 public protocol Storage {
     
-    typealias StorageType
+    associatedtype StorageType
     func writeToFile(filename: String)
     func writeToFile(url: NSURL)
     static func fromFile(filename: String) -> StorageType?


### PR DESCRIPTION
This PR removes all warnings and deprecations in XCode 7.3 / Swift 2.2; 

Note: iOS version is not buildable because APKit was built with lower version of the compiler and cannot be used