### PR TITLE
Fixed the answers in the XOR example

### DIFF
--- a/Examples/OS X/Swift-AI-OSX/XOR.swift
+++ b/Examples/OS X/Swift-AI-OSX/XOR.swift
@@ -26,8 +26,8 @@ func xorTwoWay() {
     let answers: [[Float]] = [
         [0],
         [1],
-        [0],
-        [1]
+        [1],
+        [0]
     ]
     
     // Train the network


### PR DESCRIPTION
The last two answers were swapped, so the neural network wasn't actually trained to find the xor of two values, but rather just the second of two values. 😜