### PR TITLE
Make 'error' public so it can be used upstream

### DIFF
--- a/Source/FFNN.swift
+++ b/Source/FFNN.swift
@@ -414,7 +414,7 @@ public extension FFNN {
     }
     
     /// Computes the error over the given training set.
-    private func error(result: [[Float]], expected: [[Float]]) throws -> Float {
+    public func error(result: [[Float]], expected: [[Float]]) throws -> Float {
         var errorSum: Float = 0
         switch self.errorFunction {
         case .Default(let average):


### PR DESCRIPTION
This makes it possible to use your own training loop and provide error statistics for different training sets.