### PR TITLE
Added Package.swift and updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_Store 
-
+*.xcodeproj
 
 Examples/OS X/Swift-AI-OSX.xcodeproj/project.xcworkspace/xcuserdata/*
 Examples/OS X/Swift-AI-OSX.xcodeproj/xcuserdata/*

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,6 @@
+import PackageDescription
+
+let package = Package(
+    name: "Swift-AI",
+    dependencies: []
+)


### PR DESCRIPTION
Added Package.swift for use with the Swift Package Manager. It's still
in development but I'm sure some great news will be announced at WWDC
regarding an Xcode update and integration with the SPM.
Also, added `.xcodeproj` to the gitignore file so that developers may
create a local Xcode project on their machine using `swift build -x`.
